### PR TITLE
feat: TypeScript type definitions for chart data models (#23)

### DIFF
--- a/StockSharp.AdvancedBacktest.Web/types/chart-data.ts
+++ b/StockSharp.AdvancedBacktest.Web/types/chart-data.ts
@@ -1,0 +1,67 @@
+/**
+ * TypeScript type definitions matching C# ChartDataModels.cs
+ * Used for type-safe JSON data loading in the visualization layer
+ */
+
+export interface ChartDataModel {
+  candles: CandleDataPoint[];
+  indicators?: IndicatorDataSeries[];
+  trades: TradeDataPoint[];
+  walkForward?: WalkForwardDataModel;
+}
+
+export interface CandleDataPoint {
+  time: number;           // Unix timestamp (seconds)
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface IndicatorDataSeries {
+  name: string;
+  color: string;
+  values: IndicatorDataPoint[];
+}
+
+export interface IndicatorDataPoint {
+  time: number;           // Unix timestamp (seconds)
+  value: number;
+}
+
+export interface TradeDataPoint {
+  time: number;           // Unix timestamp (seconds)
+  price: number;
+  volume: number;
+  side: 'buy' | 'sell';
+  pnL: number;
+}
+
+export interface WalkForwardDataModel {
+  walkForwardEfficiency: number;
+  consistency: number;
+  totalWindows: number;
+  windows: WalkForwardWindowData[];
+}
+
+export interface WalkForwardWindowData {
+  windowNumber: number;
+  trainingStart: number;  // Unix timestamp (seconds)
+  trainingEnd: number;    // Unix timestamp (seconds)
+  testingStart: number;   // Unix timestamp (seconds)
+  testingEnd: number;     // Unix timestamp (seconds)
+  trainingMetrics: WalkForwardMetricsData;
+  testingMetrics: WalkForwardMetricsData;
+  performanceDegradation: number;
+}
+
+export interface WalkForwardMetricsData {
+  totalReturn: number;
+  sharpeRatio: number;
+  sortinoRatio: number;
+  maxDrawdown: number;
+  winRate: number;
+  profitFactor: number;
+  totalTrades: number;
+}

--- a/StockSharp.AdvancedBacktest.Web/types/index.ts
+++ b/StockSharp.AdvancedBacktest.Web/types/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Central export point for all TypeScript type definitions
+ */
+
+export type {
+  ChartDataModel,
+  CandleDataPoint,
+  IndicatorDataSeries,
+  IndicatorDataPoint,
+  TradeDataPoint,
+  WalkForwardDataModel,
+  WalkForwardWindowData,
+  WalkForwardMetricsData,
+} from './chart-data';


### PR DESCRIPTION
## Summary
- Implements TypeScript type definitions matching C# ChartDataModels.cs
- Ensures type safety when loading JSON data in the visualization layer
- Completes issue #23

## Changes Made
- ✅ Created `types/chart-data.ts` with all required interfaces
- ✅ Added `CandleDataPoint` interface for OHLCV candle data
- ✅ Added `TradeDataPoint` interface for trade execution data
- ✅ Added `IndicatorDataSeries` and `IndicatorDataPoint` for indicator visualization
- ✅ Added `WalkForwardDataModel` with window and metrics interfaces
- ✅ Created `types/index.ts` to export all types
- ✅ All numeric fields properly typed as `number`
- ✅ Optional fields marked with `?`
- ✅ Trade side uses strict union type `'buy' | 'sell'` instead of generic string

## Type Mapping
| C# Type | TypeScript Type |
|---------|----------------|
| `long` | `number` |
| `double` | `number` |
| `int` | `number` |
| `List<T>` | `T[]` |
| `string` | `string` |
| `nullable?` | `optional?` |

## Testing
- Types match C# models exactly
- All timestamp fields documented as Unix timestamps (seconds)
- Stricter typing for trade side improves type safety

## Next Steps
Issue #24 will use these types for JSON data loading and validation

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)