### PR TITLE
feat: implement responsive design for chart components (#32)

### DIFF
--- a/StockSharp.AdvancedBacktest.Web/components/charts/CandlestickChart.tsx
+++ b/StockSharp.AdvancedBacktest.Web/components/charts/CandlestickChart.tsx
@@ -143,7 +143,7 @@ export default function CandlestickChart({ data }: Props) {
 
   return (
     <div className="relative w-full">
-      <div ref={chartContainerRef} className="w-full h-[600px]" />
+      <div ref={chartContainerRef} className="w-full h-[400px] md:h-[600px]" />
 
       {/* Trade Markers Legend */}
       <div className="absolute top-4 right-4 bg-white/90 backdrop-blur-sm border border-gray-200 rounded-lg shadow-md p-3 space-y-2">

--- a/StockSharp.AdvancedBacktest.Web/components/charts/EquityCurveChart.tsx
+++ b/StockSharp.AdvancedBacktest.Web/components/charts/EquityCurveChart.tsx
@@ -171,7 +171,7 @@ export default function EquityCurveChart({ trades }: Props) {
 
   return (
     <div className="relative w-full">
-      <div ref={chartContainerRef} className="w-full h-[300px]" />
+      <div ref={chartContainerRef} className="w-full h-[250px] md:h-[300px]" />
 
       {/* Chart Legend */}
       <div className="absolute top-4 left-4 bg-white/90 backdrop-blur-sm border border-gray-200 rounded-lg shadow-md p-3 space-y-2">


### PR DESCRIPTION
## Summary
Implemented responsive design for all chart components to ensure optimal viewing experience across tablet and desktop screen sizes.

## Changes Made
- **CandlestickChart**: Added responsive height using Tailwind breakpoints
  - Mobile (< 768px): 400px height
  - Desktop (≥ 768px): 600px height
- **EquityCurveChart**: Added responsive height using Tailwind breakpoints
  - Mobile (< 768px): 250px height
  - Desktop (≥ 768px): 300px height
- Window resize handlers already implemented in both charts
- MetricsGrid already uses responsive grid layout (1/2/4 columns)

## Acceptance Criteria
- [x] Chart resizes on window resize (handlers already present in both charts)
- [x] Metrics grid adapts to screen width (already implemented with Tailwind grid)
- [x] Tailwind breakpoints properly used (`h-[400px] md:h-[600px]`)
- [x] Minimum width: 768px (tablet) - using `md:` breakpoint
- [x] Chart height adjusts for small screens (reduced heights for mobile)
- [x] Tailwind responsive classes used throughout

## Testing
- ✅ Linting passed (`npm run lint`)
- ✅ Build completed successfully (`npm run build`)
- ✅ Static export generated without errors

## Technical Details
The implementation follows the requirements from issue #32:
- Resize handlers were already present and functional
- Added responsive height classes using Tailwind's `md:` breakpoint (768px)
- MetricsGrid already implemented with proper responsive grid breakpoints

## Related Issues
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)