### PR TITLE
[Week 3] feat: Strategy Core Structure - PreviousWeekRangeBreakoutStrategy

### DIFF
--- a/StockSharp.AdvancedBacktest.LauncherTemplate/Strategies/.gitkeep
+++ b/StockSharp.AdvancedBacktest.LauncherTemplate/Strategies/.gitkeep
@@ -1,1 +1,0 @@
-# This file ensures the Strategies directory is tracked by Git

--- a/StockSharp.AdvancedBacktest.LauncherTemplate/Strategies/PreviousWeekRangeBreakoutStrategy.cs
+++ b/StockSharp.AdvancedBacktest.LauncherTemplate/Strategies/PreviousWeekRangeBreakoutStrategy.cs
@@ -1,0 +1,153 @@
+using System;
+using StockSharp.Algo.Strategies;
+using StockSharp.Algo.Indicators;
+using StockSharp.AdvancedBacktest.Strategies;
+
+namespace StockSharp.AdvancedBacktest.LauncherTemplate.Strategies;
+
+public enum IndicatorType
+{
+	SMA,
+	EMA
+}
+
+public enum StopLossMethod
+{
+	Percentage,
+	ATR
+}
+
+public enum TakeProfitMethod
+{
+	Percentage,
+	ATR,
+	RiskReward
+}
+
+public enum PositionSizingMethod
+{
+	Fixed,
+	PercentOfEquity,
+	ATRBased
+}
+
+public class PreviousWeekRangeBreakoutStrategy : CustomStrategyBase
+{
+	private readonly StrategyParam<int> _trendFilterPeriod;
+	private readonly StrategyParam<IndicatorType> _trendFilterType;
+	private readonly StrategyParam<StopLossMethod> _stopLossMethod;
+	private readonly StrategyParam<decimal> _stopLossPercentage;
+	private readonly StrategyParam<decimal> _stopLossATRMultiplier;
+	private readonly StrategyParam<int> _atrPeriod;
+	private readonly StrategyParam<TakeProfitMethod> _takeProfitMethod;
+	private readonly StrategyParam<decimal> _takeProfitPercentage;
+	private readonly StrategyParam<decimal> _takeProfitATRMultiplier;
+	private readonly StrategyParam<decimal> _riskRewardRatio;
+	private readonly StrategyParam<PositionSizingMethod> _sizingMethod;
+	private readonly StrategyParam<decimal> _fixedPositionSize;
+	private readonly StrategyParam<decimal> _equityPercentage;
+
+	public int TrendFilterPeriod
+	{
+		get => _trendFilterPeriod.Value;
+		set => _trendFilterPeriod.Value = value;
+	}
+
+	public IndicatorType TrendFilterType
+	{
+		get => _trendFilterType.Value;
+		set => _trendFilterType.Value = value;
+	}
+
+	public StopLossMethod StopLossMethodValue
+	{
+		get => _stopLossMethod.Value;
+		set => _stopLossMethod.Value = value;
+	}
+
+	public decimal StopLossPercentage
+	{
+		get => _stopLossPercentage.Value;
+		set => _stopLossPercentage.Value = value;
+	}
+
+	public decimal StopLossATRMultiplier
+	{
+		get => _stopLossATRMultiplier.Value;
+		set => _stopLossATRMultiplier.Value = value;
+	}
+
+	public int ATRPeriod
+	{
+		get => _atrPeriod.Value;
+		set => _atrPeriod.Value = value;
+	}
+
+	public TakeProfitMethod TakeProfitMethodValue
+	{
+		get => _takeProfitMethod.Value;
+		set => _takeProfitMethod.Value = value;
+	}
+
+	public decimal TakeProfitPercentage
+	{
+		get => _takeProfitPercentage.Value;
+		set => _takeProfitPercentage.Value = value;
+	}
+
+	public decimal TakeProfitATRMultiplier
+	{
+		get => _takeProfitATRMultiplier.Value;
+		set => _takeProfitATRMultiplier.Value = value;
+	}
+
+	public decimal RiskRewardRatio
+	{
+		get => _riskRewardRatio.Value;
+		set => _riskRewardRatio.Value = value;
+	}
+
+	public PositionSizingMethod SizingMethod
+	{
+		get => _sizingMethod.Value;
+		set => _sizingMethod.Value = value;
+	}
+
+	public decimal FixedPositionSize
+	{
+		get => _fixedPositionSize.Value;
+		set => _fixedPositionSize.Value = value;
+	}
+
+	public decimal EquityPercentage
+	{
+		get => _equityPercentage.Value;
+		set => _equityPercentage.Value = value;
+	}
+
+	private decimal? _previousWeekHigh;
+	private decimal? _previousWeekLow;
+	private DateTimeOffset? _currentWeekStartTime;
+	private decimal _weekHigh;
+	private decimal _weekLow;
+	private IIndicator? _trendFilter;
+	private AverageTrueRange? _atr;
+	private bool _hasBreakoutOccurred;
+
+	public PreviousWeekRangeBreakoutStrategy()
+	{
+		_trendFilterPeriod = Param(nameof(TrendFilterPeriod), 50);
+		_trendFilterType = Param(nameof(TrendFilterType), IndicatorType.SMA);
+		_stopLossMethod = Param(nameof(StopLossMethodValue), Strategies.StopLossMethod.Percentage);
+		_stopLossPercentage = Param(nameof(StopLossPercentage), 2.0m);
+		_stopLossATRMultiplier = Param(nameof(StopLossATRMultiplier), 2.0m);
+		_atrPeriod = Param(nameof(ATRPeriod), 14);
+		_takeProfitMethod = Param(nameof(TakeProfitMethodValue), Strategies.TakeProfitMethod.Percentage);
+		_takeProfitPercentage = Param(nameof(TakeProfitPercentage), 4.0m);
+		_takeProfitATRMultiplier = Param(nameof(TakeProfitATRMultiplier), 3.0m);
+		_riskRewardRatio = Param(nameof(RiskRewardRatio), 2.0m);
+		_sizingMethod = Param(nameof(SizingMethod), PositionSizingMethod.Fixed);
+		_fixedPositionSize = Param(nameof(FixedPositionSize), 0.01m);
+		_equityPercentage = Param(nameof(EquityPercentage), 2.0m);
+	}
+}


### PR DESCRIPTION
## Overview
Implements the core structure of `PreviousWeekRangeBreakoutStrategy` with all optimizable parameters as defined in issue #76.

## Changes
### Enums Added (4 total)
- `IndicatorType` - SMA, EMA
- `StopLossMethod` - Percentage, ATR
- `TakeProfitMethod` - Percentage, ATR, RiskReward
- `PositionSizingMethod` - Fixed, PercentOfEquity, ATRBased

### Optimizable Parameters (13 total)
All parameters implemented with correct types and default values:
- Trend Filter: `TrendFilterPeriod` (int, 50), `TrendFilterType` (SMA)
- Stop Loss: `StopLossMethodValue` (Percentage), `StopLossPercentage` (2.0), `StopLossATRMultiplier` (2.0), `ATRPeriod` (14)
- Take Profit: `TakeProfitMethodValue` (Percentage), `TakeProfitPercentage` (4.0), `TakeProfitATRMultiplier` (3.0), `RiskRewardRatio` (2.0)
- Position Sizing: `SizingMethod` (Fixed), `FixedPositionSize` (0.01), `EquityPercentage` (2.0)

### Private Fields for State Tracking
- Week range tracking: `_previousWeekHigh`, `_previousWeekLow`, `_currentWeekStartTime`, `_weekHigh`, `_weekLow`
- Indicators: `_trendFilter`, `_atr`
- State: `_hasBreakoutOccurred`

## Code Quality
- ✅ Clean, self-documenting code (no XML comments)
- ✅ No unnecessary regions
- ✅ Follows StockSharp `StrategyParam<T>` pattern
- ✅ Compiles without errors
- ✅ Inherits from `CustomStrategyBase` correctly

## Testing
- Verified compilation with no errors
- All parameters properly initialized with defaults
- Ready for future logic implementation

## Notes
- This is a **structure-only** implementation
- Trading logic will be added in subsequent issues
- Enums are strategy-specific and don't conflict with StockSharp's existing types

Closes #76